### PR TITLE
stm32u5 hal dma_ex function not inlined with GCC 11 or 12

### DIFF
--- a/platform/ext/target/stm/common/stm32u5xx/hal/Src/stm32u5xx_hal_dma_ex.c
+++ b/platform/ext/target/stm/common/stm32u5xx/hal/Src/stm32u5xx_hal_dma_ex.c
@@ -525,6 +525,12 @@
 
 #ifdef HAL_DMA_MODULE_ENABLED
 
+#if (__GNUC__ == 11) || (__GNUC__ == 12)
+#define ATTRIB  __attribute__ ((noinline))
+#else
+#define ATTRIB
+#endif
+
 /* Private types -----------------------------------------------------------------------------------------------------*/
 /* Private variables -------------------------------------------------------------------------------------------------*/
 /* Private Constants -------------------------------------------------------------------------------------------------*/
@@ -4074,7 +4080,7 @@ static void DMA_List_GetNodeConfig(DMA_NodeConfTypeDef *const pNodeConfig,
   * @param  pNode4 : Pointer to a DMA_NodeTypeDef structure that contains linked-list node 4 registers configurations.
   * @retval Return 0 when nodes addresses are compatible, 1 otherwise.
   */
-static uint32_t DMA_List_CheckNodesBaseAddresses(DMA_NodeTypeDef const *const pNode1,
+static  ATTRIB uint32_t DMA_List_CheckNodesBaseAddresses(DMA_NodeTypeDef const *const pNode1,
                                                  DMA_NodeTypeDef const *const pNode2,
                                                  DMA_NodeTypeDef const *const pNode3,
                                                  DMA_NodeTypeDef const *const pNode4)


### PR DESCRIPTION
Fix the Issue linked to compilation of file HAL_DMAEx_List_ReplaceNode_Head.c
using a GCC version comprised between v11.x and v12.x.

and blocking the zephyr CI

Issue is seen only with TF-M build config RelWithDebInfo (With MinSizeRel config, this file is not built).
Issue could be fixed by "adding attribute ((no_inline)) to DMA_List_CheckNodesBaseAddresses allows the build to pass"

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/80932

Change-Id: Idb1795ad722b8742355823afb2101c749aaba864